### PR TITLE
Removed deprecated, extracted gems from idioms

### DIFF
--- a/idioms.gemspec
+++ b/idioms.gemspec
@@ -20,15 +20,13 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activesupport", ">= 3.2.0"
   spec.add_dependency "faraday-raise-errors", ">= 0.2.0"
-  spec.add_dependency "activerecord-insert_many"
-  spec.add_dependency "activerecord-pluck_in_batches"
-  spec.add_dependency "minitest-reporters-turn_reporter"
 
-  spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "minitest-reporters"
+  spec.add_development_dependency "minitest-reporters-turn_reporter"
   spec.add_development_dependency "shoulda-context"
   spec.add_development_dependency "timecop"
 end

--- a/lib/idioms/active_record/insert_many.rb
+++ b/lib/idioms/active_record/insert_many.rb
@@ -1,2 +1,0 @@
-puts "\e[33mDEPRECATED: Use the `activerecord-insert_many` gem instead\e[0m"
-require "activerecord/insert_many"

--- a/lib/idioms/active_record/pluck_in_batches.rb
+++ b/lib/idioms/active_record/pluck_in_batches.rb
@@ -1,2 +1,0 @@
-puts "\e[33mDEPRECATED: Use the `activerecord-pluck_in_baches` gem instead\e[0m"
-require "activerecord/pluck_in_batches"

--- a/lib/idioms/minitest/reporter.rb
+++ b/lib/idioms/minitest/reporter.rb
@@ -1,8 +1,0 @@
-puts "\e[33mDEPRECATED: Use the `minitest-reporters-turn_reporter` gem instead\e[0m"
-require "minitest/reporters/turn_reporter"
-
-module Idioms
-  module Minitest
-    Reporter = ::Minitest::Reporters::TurnReporter
-  end
-end

--- a/lib/idioms/rack/catch_invalid_params.rb
+++ b/lib/idioms/rack/catch_invalid_params.rb
@@ -55,6 +55,7 @@ module Rack
       exceptions.push(MultiJson::LoadError) if _defined? "MultiJson::LoadError"
       exceptions.push(MultiJson::ParseError) if _defined? "MultiJson::ParseError"
       exceptions.push(ActionDispatch::ParamsParser::ParseError) if _defined? "ActionDispatch::ParamsParser::ParseError"
+      exceptions.push(ActionDispatch::Http::Parameters::ParseError) if _defined? "ActionDispatch::Http::Parameters::ParseError"
       exceptions
     end
 

--- a/lib/idioms/version.rb
+++ b/lib/idioms/version.rb
@@ -1,3 +1,3 @@
 module Idioms
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "idioms"
 
-require "minitest/reporters/turn_reporter"
+require "minitest-reporters-turn_reporter"
 MiniTest::Reporters.use! Minitest::Reporters::TurnReporter.new
 
 require "shoulda/context"


### PR DESCRIPTION
### Summary
These have all been long-extracted and needn't be included in `idioms`, which allows us to further bump versions of Rails and worry about compatibility with these extracted gems separately and only as-needed.